### PR TITLE
Update to stackmaxima version 2018030500 for moodle-qtype_stack

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM tomcat:9-jre10
+FROM tomcat:9-jre11
 LABEL maintainer="O: University of Halle (Saale) Germany; OU: ITZ, department application systems" \
       license="Docker composition: MIT; Components: Please check"
 
@@ -41,30 +41,8 @@ done
 #
 # 4. Remove package, which are no longer required
 RUN apt-get update \
-    && JV=${JAVA_VERSION%%[!0-9]*} \
-    && if [ $JV -lt 9 ]; then \
-        apt-get install -y openjdk-${JV}-jdk; \
-      else \
-         if [ $JV -eq 10 ]; then \
-           JDK_URL=https://download.java.net/java/GA/jdk10/10.0.2/19aef61b38124481863b1413dce1855f/13/openjdk-10.0.2_linux-x64_bin.tar.gz; \
-           JDK_HOME=/usr/lib/jvm/java-10-openjdk-amd64; \
-         fi; \
-         if [ $JV -eq 11 ]; then \
-           JDK_URL=https://download.java.net/java/GA/jdk11/13/GPL/openjdk-11.0.1_linux-x64_bin.tar.gz; \
-           JDK_HOME=/usr/lib/jvm/java-11-openjdk-amd64; \
-         fi; \
-	 echo $JDK_URL; \
-         echo $JDK_HOME; \
-         wget -O jdk.tar.gz ${JDK_URL}; \
-         tar -xzf jdk.tar.gz; \
-	 rm jdk.tar.gz; \
-         mv jdk-${JAVA_VERSION} ${JDK_HOME}; \
-	 update-alternatives --install /usr/bin/java java ${JDK_HOME}/jdk-${JAVA_VERSION}/bin/java 1; \
-	 update-alternatives --set java ${JDK_HOME}/jdk-${JAVA_VERSION}/bin/java; \
-	 update-alternatives --install /usr/bin/javac javac ${JDK_HOME}/jdk-${JAVA_VERSION}/bin/javac 1; \
-	 update-alternatives --set javac ${JDK_HOME}/jdk-${JAVA_VERSION}/bin/javac; \
-      fi \
     && apt-get install -y \
+      openjdk-${JAVA_VERSION%%[!0-9]*}-jdk \
       ant \
       wget \
       gnuplot \

--- a/README.md
+++ b/README.md
@@ -25,7 +25,8 @@ There are multiple versions/ tags available under [dockerhub:unihalle/maximapool
 
 | Tag                | STACK version | OS/Tomcat/JRE   | Maxima version | assStackQuestion | ILIAS | moodle-qtype_stack |
 |:------------------ | -------------:| --------------- | --------------:| ----------------:| ----- | ------------------ |
-| `latest`           | 2017121800    | debian sid/9/10 | 5.41.0-Linux   | 12439ff          | 5.3   |4.1
+| `latest`           | 2018030500    | debian sid/9/10 | 5.41.0-Linux   |                  |       |4.1+ [(9bf7a7f)](https://github.com/maths/moodle-qtype_stack/tree/9bf7a7ff6118086480f2b3db5fbb933150c8fa49)
+| `stack-2018030500` | 2018030500    | debian sid/9/10 | 5.41.0-Linux   |                  |       |4.1+ [(9bf7a7f)](https://github.com/maths/moodle-qtype_stack/tree/9bf7a7ff6118086480f2b3db5fbb933150c8fa49)
 | `stack-2017121800` | 2017121800    | debian sid/9/10 | 5.41.0-Linux   | 12439ff          | 5.3   |4.1
 | `stack-2014083000` | 2014083000    | debian sid/9/9  | 5.41.0-Linux   | c23c787 / 9a42ef8 [with patch](https://github.com/ilifau/assStackQuestion/issues/32) | 5.0-5.1 / 5.2 |3.3
 


### PR DESCRIPTION
Further to our discussion in #5 

I have created a branch to create an updated build for stackmaxima 2018030500.  I had to make some changes to the Dockerfile to get it to build, since it's using Java 10 and JDK > 8 requires manual installation.  Other than that it just includes the commit of moodle-qtype_stack wheter the stackmaxima version is as required.

I looked for a version of assStackQuestion with the corresponding stackmaxima version, but it appears their latest version is still 2017121800.  I assume that just means that this version of the container will only work with Moodle?

Other than that, any feedback is welcome, as this is my first time doing anything like this!

**Checklist**
- [x] [Applied best practice writing docker files](https://developers.redhat.com/blog/2016/02/24/10-things-to-avoid-in-docker-containers/)
- [x] README.md updated or doen't require changes
- [x] `assets/maximalocal.mac.template` and `assets/optimize.mac` still match the STACK-version
_I'm not sure what, if anything, needs changing here._
- [x] No code smells introduced (e.g. used ShellCheck for Shell scripts)
_No changes to shell scripts._
