### PR TITLE
Update moodle-qtype_stack to version 4.2.1

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,7 +25,8 @@ There are multiple versions/ tags available under [dockerhub:unihalle/maximapool
 
 | Tag                | STACK version | OS/Tomcat/JRE   | Maxima version | assStackQuestion | ILIAS | moodle-qtype_stack |
 |:------------------ | -------------:| --------------- | --------------:| ----------------:| ----- | ------------------ |
-| `latest`           | 2018030500    | debian sid/9/11 | 5.41.0-Linux   |                  |       |4.1+ [(9bf7a7f)](https://github.com/maths/moodle-qtype_stack/tree/9bf7a7ff6118086480f2b3db5fbb933150c8fa49)
+| `latest`           | 2018080600    | debian sid/9/11 | 5.41.0-Linux   |                  |       |4.2.1 		|
+| `stack-2018080600` | 2018080600    | debian sid/9/11 | 5.41.0-Linux   |                  |       |4.2.1 		|
 | `stack-2018030500` | 2018030500    | debian sid/9/11 | 5.41.0-Linux   |                  |       |4.1+ [(9bf7a7f)](https://github.com/maths/moodle-qtype_stack/tree/9bf7a7ff6118086480f2b3db5fbb933150c8fa49)
 | `stack-2017121800` | 2017121800    | debian sid/9/10 | 5.41.0-Linux   | 12439ff          | 5.3   |4.1
 | `stack-2014083000` | 2014083000    | debian sid/9/9  | 5.41.0-Linux   | c23c787 / 9a42ef8 [with patch](https://github.com/ilifau/assStackQuestion/issues/32) | 5.0-5.1 / 5.2 |3.3


### PR DESCRIPTION
This includes the latest stable release of moodle-qtype_stack.  It all appears to build without any issues, and no other updates required.

**Checklist**
- [x] [Applied best practice writing docker files](https://developers.redhat.com/blog/2016/02/24/10-things-to-avoid-in-docker-containers/)
- [x] README.md updated or doen't require changes
- [x] `assets/maximalocal.mac.template` and `assets/optimize.mac` still match the STACK-version
  _Usually the LMS (ILIAS/ Moodle) plugins create a file in which they store their settings for STACK-Maxima, for example [defining a default size for plots](https://github.com/uni-halle/maximapool-docker/blob/develop/assets/maximalocal.mac.template#L21) or defining which modules to load._
  _In ILIAS the file is located under `/data_dir/xqcas/stack/maximalocal.mac`, in Moodle `$MOODLEDATA/stack/**/maximalocal.mac`._
  _This settings file is then loaded into any non-optimized STACK-Maxima. If optimization is performed, the settings file has to be pre-generated and is baked into the optimized STACK-Maxima._
- [x] No code smells introduced (e.g. used ShellCheck for Shell scripts)
